### PR TITLE
fix: correct bot order status filter value from 'canceled' to 'finished'

### DIFF
--- a/openapi_bot.yaml
+++ b/openapi_bot.yaml
@@ -108,7 +108,7 @@ paths:
           description: |
             Order status filter:
             `running` - Running orders (default),
-            `canceled` - Closed/cancelled orders
+            `finished` - Closed/cancelled orders
           schema:
             type: string
             default: running


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                                  
  - Fix the bot order list endpoint (`GET /api/v1/bot/orders`) status filter: change `canceled` to `finished` to match the actual API behavior for closed/cancelled orders. 