### PR TITLE
docs: update beta/invite-only notices and add UID requirement for con…

### DIFF
--- a/openapi_bot.yaml
+++ b/openapi_bot.yaml
@@ -8,8 +8,6 @@ info:
 
     ## Basic Info
 
-    > **Note:** The Bot API is currently in **Beta**. If you would like to use it, please contact us at [open@pionex.com](mailto:open@pionex.com).
-
     **Base URL:** `https://api.pionex.com`
 
     **Request Format:**

--- a/openapi_earn_dual.yaml
+++ b/openapi_earn_dual.yaml
@@ -8,7 +8,7 @@ info:
 
     ## Basic Info
 
-    > **Note:** The Dual Investment API is currently in **Beta**. If you would like to use it, please contact us at [open@pionex.com](mailto:open@pionex.com).
+    > **Note:** The Dual Investment API is currently in **Beta**. If you would like to use it, please contact us at [open@pionex.com](mailto:open@pionex.com) with your UID and reason for applying.
 
     **Base URL:** `https://api.pionex.com`
 

--- a/openapi_futures.yaml
+++ b/openapi_futures.yaml
@@ -8,7 +8,7 @@ info:
 
     ## Basic Info
 
-    > **Note:** The Futures API is currently in **Beta**. If you would like to use it, please contact us at [open@pionex.com](mailto:open@pionex.com).
+    > **Note:** The Partner API is currently **Invite Only**.
 
     **Base URL:** `https://api.pionex.com`
 

--- a/websocketapi_futures.yaml
+++ b/websocketapi_futures.yaml
@@ -9,7 +9,7 @@ info:
 
     ## Connection Endpoints
 
-    > **Note:** The Futures API is currently in **Beta**. If you would like to use it, please contact us at [open@pionex.com](mailto:open@pionex.com).
+    > **Note:** The Partner API is currently **Invite Only**.
 
     - **Public stream**: `wss://ws.pionex.com/wsPub` (no authentication)
     - **Private stream**: `wss://ws.pionex.com/wsUA` (requires authentication)


### PR DESCRIPTION
…tact

- Remove beta notice from Bot API
- Add UID and reason requirement to Dual Investment API contact note
- Update Futures API and Futures WebSocket notes to "Invite Only"