### PR TITLE
fix: remove LOCK_ACTIVITY from futuresGrid create investmentFrom enum

### DIFF
--- a/openapi_bot.yaml
+++ b/openapi_bot.yaml
@@ -1536,8 +1536,8 @@ components:
           description: "Investment currency: `USDT` or quote currency (default)"
         investmentFrom:
           type: string
-          description: "Funding source: `USER` (default), `LOCK_ACTIVITY`, `FUTURE_GRID_BONUS`"
-          enum: [USER, LOCK_ACTIVITY, FUTURE_GRID_BONUS]
+          description: "Funding source: `USER` (default), `FUTURE_GRID_BONUS`"
+          enum: [USER, FUTURE_GRID_BONUS]
         uiInvestCoin:
           type: string
           description: Frontend-recorded investment currency type (stored only)


### PR DESCRIPTION
Closes #24

  Remove `LOCK_ACTIVITY` from the `investmentFrom` enum in `CreateFuturesGridOrderData` (the create request schema).

  The backend already rejects this value for Open API requests. The response schema (`FuturesGridOrderData`) retains `LOCK_ACTIVITY` for backward compatibility.
