### PR TITLE
docs: add InstFund Open API spec

### DIFF
--- a/openapi_inst_fund.yaml
+++ b/openapi_inst_fund.yaml
@@ -1,0 +1,393 @@
+openapi: 3.0.3
+info:
+  title: Pionex InstFund Open API
+  description: |
+    Pionex cryptocurrency exchange InstFund RESTful API - Institutional fiat deposit, withdrawal, and fee query endpoints.
+
+    # General Info
+
+    ## Basic Info
+
+    > **Note:** The InstFund API is currently **Invite Only** and only available to onboarded institutional users. If you would like to use it, please contact your BD representative or [open@pionex.com](mailto:open@pionex.com).
+
+    **Base URL:** `https://api.pionex.com`
+
+    **Request Format:**
+    - All endpoints require a Trade Token in the `Authorization` header.
+    - GET requests: additional parameters are passed in the query string using camelCase naming.
+    - POST requests: parameters are passed in the request body as JSON (`application/json`) using camelCase naming.
+
+    **Response Format:**
+
+    All responses are JSON objects containing:
+    - `result` (boolean): success indicator
+    - `timestamp` (number): response timestamp in milliseconds
+    - On success: `data` object with business information (JSON keys returned in camelCase)
+    - On failure: `code` (string) and `message` (string) with error details
+
+    Success example:
+    ```json
+    {"result": true, "data": {"totalAmount": "100", "fee": "0.5", "netAmount": "99.5"}, "timestamp": 1566691672311}
+    ```
+
+    Failure example:
+    ```json
+    {"result": false, "code": "BOT_INTERNAL_ERROR", "message": "internal error", "timestamp": 1566691672311}
+    ```
+
+    ## Rate Limits
+
+    - Each endpoint has a weight value that determines how many requests it counts toward the limit.
+    - IP-based and account-based limits operate independently.
+    - All endpoints share the 10 per second limit based on IP.
+    - Private endpoints share the 10 per second limit based on ACCOUNT.
+    - Exceeding the weight limit results in HTTP 429 status code.
+
+    ## Authentication
+
+    Private endpoints require Trade Token authentication.
+
+    **Required header:**
+    - `Authorization: Bearer <trade_token>` — a Trade Token issued by the Pionex Trade Token Service
+
+    The Trade Token is verified on every request and its payload identifies the acting user. Missing or malformed tokens are rejected with `BOT_INVALID_TOKEN`.
+
+    ### API Key Permissions
+
+    Each API Key can be configured with **`Enable reading`** and/or **`Institutional deposit & withdrawal`** permissions. Make sure your API Key has the appropriate permission enabled before calling the following endpoints.
+
+    **Endpoints requiring `Enable reading` permission:**
+    - `GET /api/v1/instFund/straitsx/getAccount` — Query the InstFund virtual account
+    - `GET /api/v1/instFund/straitsx/getWithdrawAccounts` — List bound withdraw accounts
+    - `GET /api/v1/instFund/common/getDeposits` — Query fiat deposit history
+    - `GET /api/v1/instFund/common/getWithdraws` — Query fiat withdrawal history
+    - `GET /api/v1/instFund/common/getFee` — Query withdrawal fee
+
+    **Endpoints requiring `Institutional deposit & withdrawal` permission:**
+    - `POST /api/v1/instFund/straitsx/createWithdraw` — Create a fiat withdrawal request
+
+  version: 1.0.0
+  contact:
+    name: Pionex API Support
+    url: https://t.me/pionexapi
+
+servers:
+  - url: https://api.pionex.com
+    description: Production
+
+security: []
+
+tags:
+  - name: InstFund - Account
+    description: InstFund virtual account, bound withdraw accounts, and fiat withdrawal endpoints (private)
+  - name: InstFund - Common
+    description: Fiat deposit / withdrawal history and fee query endpoints (private)
+
+paths:
+  # -------------------------------------------------------------------------
+  # Account & withdrawal
+  # -------------------------------------------------------------------------
+
+  /api/v1/instFund/straitsx/getAccount:
+    get:
+      tags: [InstFund - Account]
+      summary: Query the InstFund virtual account
+      description: |
+        Returns the InstFund virtual account bound to the authenticated user. Weight: 1.
+      operationId: instFundGetAccount
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Virtual account details
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/instFund/straitsx/getWithdrawAccounts:
+    get:
+      tags: [InstFund - Account]
+      summary: List bound withdraw accounts
+      description: |
+        Returns the list of withdraw accounts bound to the authenticated user. Weight: 1.
+      operationId: instFundGetWithdrawAccounts
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Bound withdraw account list
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/instFund/straitsx/createWithdraw:
+    post:
+      tags: [InstFund - Account]
+      summary: Create a fiat withdrawal request
+      description: |
+        Creates a fiat withdrawal request against a bound withdraw account. Weight: 1.
+
+        The request body should use camelCase keys.
+      operationId: instFundCreateWithdraw
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Withdrawal request payload (camelCase keys)
+              additionalProperties: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Withdrawal creation result
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # -------------------------------------------------------------------------
+  # Common
+  # -------------------------------------------------------------------------
+
+  /api/v1/instFund/common/getDeposits:
+    get:
+      tags: [InstFund - Common]
+      summary: Query fiat deposit history
+      description: |
+        Returns fiat deposit history for the authenticated user. Weight: 1.
+      operationId: instFundGetDeposits
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Deposit history
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/instFund/common/getWithdraws:
+    get:
+      tags: [InstFund - Common]
+      summary: Query fiat withdrawal history
+      description: |
+        Returns fiat withdrawal history for the authenticated user. Weight: 1.
+      operationId: instFundGetWithdraws
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Withdrawal history
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/instFund/common/getFee:
+    get:
+      tags: [InstFund - Common]
+      summary: Query withdrawal fee
+      description: |
+        Query the withdrawal fee for a given amount and channel. Currently only the withdrawal direction is supported. Weight: 1.
+
+        Example request:
+        ```
+        GET /api/v1/instFund/common/getFee?amount=100&direction=withdraw
+        ```
+
+        Example response:
+        ```json
+        {
+          "result": true,
+          "data": {
+            "totalAmount": "100",
+            "fee": "0.5",
+            "netAmount": "99.5"
+          },
+          "timestamp": 1774959429596
+        }
+        ```
+      operationId: instFundGetFee
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          description: "Optional channel identifier. Leave empty to use the default channel bound to your account."
+          schema:
+            type: string
+        - name: amount
+          in: query
+          required: true
+          description: "Total amount to query the fee for (decimal string, in the quote currency U)."
+          schema:
+            type: string
+          example: "100"
+        - name: direction
+          in: query
+          required: false
+          description: "Fee direction. Only `withdraw` is currently supported; defaults to `withdraw`."
+          schema:
+            type: string
+            default: withdraw
+            enum: [withdraw]
+          example: withdraw
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/GetFeeData'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: TradeToken
+      description: |
+        Trade Token authentication. Provide the token in the `Authorization` header as `Bearer <trade_token>`. The Trade Token is issued by the Pionex Trade Token Service and is verified on every request.
+
+  schemas:
+    BaseResponse:
+      type: object
+      properties:
+        result:
+          type: boolean
+          description: Success indicator
+        timestamp:
+          type: integer
+          format: int64
+          description: Response timestamp in milliseconds
+        code:
+          type: string
+          description: Error code (present only on failure)
+        message:
+          type: string
+          description: Error message (present only on failure)
+
+    GetFeeData:
+      type: object
+      description: Withdrawal fee query result
+      properties:
+        totalAmount:
+          type: string
+          description: Total amount requested
+          example: "100"
+        fee:
+          type: string
+          description: Withdrawal fee
+          example: "0.5"
+        netAmount:
+          type: string
+          description: "Amount credited to the counterparty (for withdrawal: total amount minus fee)"
+          example: "99.5"
+
+  responses:
+    BadRequest:
+      description: Bad Request - Invalid parameters
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/BaseResponse'
+          example:
+            result: false
+            code: BOT_INVALID_ARGUMENT
+            message: invalid parameter
+            timestamp: 1566691672311
+
+    Unauthorized:
+      description: Unauthorized - Missing or invalid Trade Token
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/BaseResponse'
+          example:
+            result: false
+            code: BOT_INVALID_TOKEN
+            message: invalid bearer token format
+            timestamp: 1566691672311
+
+    InternalError:
+      description: Internal error - service or business error. A human-readable `message` is returned when available.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/BaseResponse'
+          example:
+            result: false
+            code: BOT_INTERNAL_ERROR
+            message: internal error
+            timestamp: 1566691672311


### PR DESCRIPTION
Add openapi_inst_fund.yaml covering the institutional fiat deposit, withdrawal, and fee query endpoints under /api/v1/instFund.